### PR TITLE
fix(activity): wrong form description

### DIFF
--- a/src/module/activity/component/Form/Title.tsx
+++ b/src/module/activity/component/Form/Title.tsx
@@ -1,13 +1,16 @@
 import { Dialog } from '@headlessui/react';
 
+import { activityTypeLabel, ActivityType } from '../../entity';
 import { useFormStore } from '../../store';
 
 export const Title = (): React.JSX.Element => {
-  const { formType } = useFormStore();
+  const { formType, activity } = useFormStore();
+  const label: string = activityTypeLabel[formType as ActivityType] ?? '';
+  const action: string = activity ? 'Update' : 'Create';
 
   return (
     <Dialog.Title className="text-lg font-medium leading-6 text-gray-900">
-      Create {formType} Murojaah
+      {action} {label} Murojaah
     </Dialog.Title>
   );
 };

--- a/src/module/activity/entity/index.ts
+++ b/src/module/activity/entity/index.ts
@@ -8,6 +8,13 @@ export enum ActivityType {
   Ayah = 2,
 }
 
+export const activityTypeLabel: Record<ActivityType, string> = {
+  [ActivityType.Uninitialized]: '',
+  [ActivityType.Juz]: 'Juz',
+  [ActivityType.Surah]: 'Surah',
+  [ActivityType.Ayah]: 'Ayah',
+};
+
 export type Activity = {
   id: string;
   activityType: ActivityType;


### PR DESCRIPTION
## Summary

Fixes the activity form dialog title to display human-readable activity type names ("Juz", "Surah", "Ayah") instead of numeric enum values (0, 1, 2). Also adds support for "Update" vs "Create" action text when editing existing activities.

## Changes

- **`src/module/activity/entity/index.ts`**: Added `activityTypeLabel` constant mapping `ActivityType` enum to human-readable strings
- **`src/module/activity/component/Form/Title.tsx`**: Updated to use the new label constant and detect edit mode

## Before

| Action | Title |
|--------|-------|
| Create Juz | "Create 0 Murojaah" |
| Create Surah | "Create 1 Murojaah" |
| Create Ayah | "Create 2 Murojaah" |
| Edit any | "Create X Murojaah" |

## After

| Action | Title |
|--------|-------|
| Create Juz | "Create Juz Murojaah" |
| Create Surah | "Create Surah Murojaah" |
| Create Ayah | "Create Ayah Murojaah" |
| Edit any | "Update X Murojaah" |

## Testing

- [x] `pnpm build` passes
- [x] `pnpm lint` passes (pre-existing warnings only)
- [x] Manual testing: Create Juz/Surah/Ayah forms show correct labels
- [x] Manual testing: Edit mode shows "Update" instead of "Create"