### PR TITLE
feat: replace text datetime input with date and time picker

### DIFF
--- a/src/module/activity/component/Form/Button.tsx
+++ b/src/module/activity/component/Form/Button.tsx
@@ -26,9 +26,12 @@ interface InternalProps {
 
 const checkIsChanged = (
   formType: number,
+  activity: Activity | undefined,
   selectedJuz: Option | undefined,
   selectedSurah: Option | Option[] | undefined
 ): boolean => {
+  if (!activity) return true;
+
   switch (formType) {
     case ActivityType.Juz:
       if (!selectedJuz) return false;
@@ -242,8 +245,8 @@ export const Button = (p: Props): React.JSX.Element => {
   };
 
   const isFormChanged: boolean = useMemo(
-    () => checkIsChanged(formType, p.selectedJuz, p.selectedSurah),
-    [formType, p.selectedJuz, p.selectedSurah]
+    () => checkIsChanged(formType, activity, p.selectedJuz, p.selectedSurah),
+    [formType, activity, p.selectedJuz, p.selectedSurah]
   );
 
   const isSaveable: boolean = useMemo(

--- a/src/module/activity/component/Form/Input/DateTimeInput.tsx
+++ b/src/module/activity/component/Form/Input/DateTimeInput.tsx
@@ -2,7 +2,7 @@ import { ArrowPathIcon } from '@heroicons/react/16/solid';
 import { DateTime } from 'luxon';
 import { Dispatch, SetStateAction } from 'react';
 
-import { formFormatDatetimes, fromDatetimeLocal, toDatetimeLocal } from '@/shared/util';
+import { formFormatDatetimes, splitDatetime } from '@/shared/util';
 
 interface Props {
   value: string;
@@ -10,18 +10,42 @@ interface Props {
 }
 
 export const DateTimeInput = (p: Props): React.JSX.Element => {
+  const { date, time }: { date: string; time: string } = splitDatetime(p.value);
+
+  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const newDate: string = e.target.value;
+    const currentTime: string = time || '00:00';
+    p.setValue(`${newDate} ${currentTime}`);
+  };
+
+  const handleTimeChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const newTime: string = e.target.value;
+    const currentDate: string = date || DateTime.now().toFormat('yyyy-MM-dd');
+    p.setValue(`${currentDate} ${newTime}`);
+  };
+
+  const handleReset = (): void => {
+    p.setValue(DateTime.now().toFormat(formFormatDatetimes[0]));
+  };
+
   return (
-    <div className="flex">
+    <div className="flex gap-2">
       <input
-        className="w-full px-2 py-1 border border-gray-300"
-        type="datetime-local"
-        value={toDatetimeLocal(p.value)}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => p.setValue(fromDatetimeLocal(e.target.value))}
+        className="flex-1 px-2 py-1 border border-gray-300"
+        type="date"
+        value={date}
+        onChange={handleDateChange}
+      />
+      <input
+        className="flex-1 px-2 py-1 border border-gray-300"
+        type="time"
+        value={time}
+        onChange={handleTimeChange}
       />
       <button
         type="button"
         className="bg-blue-500 text-white px-2"
-        onClick={() => p.setValue(DateTime.now().toFormat(formFormatDatetimes[0]))}
+        onClick={handleReset}
       >
         <ArrowPathIcon className="size-5 fill-white/50" />
       </button>

--- a/src/module/activity/component/Form/Input/DateTimeInput.tsx
+++ b/src/module/activity/component/Form/Input/DateTimeInput.tsx
@@ -2,7 +2,7 @@ import { ArrowPathIcon } from '@heroicons/react/16/solid';
 import { DateTime } from 'luxon';
 import { Dispatch, SetStateAction } from 'react';
 
-import { formFormatDatetimes } from '@/shared/util';
+import { formFormatDatetimes, fromDatetimeLocal, toDatetimeLocal } from '@/shared/util';
 
 interface Props {
   value: string;
@@ -13,10 +13,10 @@ export const DateTimeInput = (p: Props): React.JSX.Element => {
   return (
     <div className="flex">
       <input
-        className="w-full px-2 py-1 border border-gray-300 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-        type="text"
-        value={p.value}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => p.setValue(e.target.value)}
+        className="w-full px-2 py-1 border border-gray-300"
+        type="datetime-local"
+        value={toDatetimeLocal(p.value)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => p.setValue(fromDatetimeLocal(e.target.value))}
       />
       <button
         type="button"

--- a/src/shared/util/datetime.ts
+++ b/src/shared/util/datetime.ts
@@ -3,14 +3,16 @@ import { DateTime, Duration } from 'luxon';
 
 export const formFormatDatetimes: string[] = ['yyyy-MM-dd HH:mm', 'yyyy-MM-dd HH.mm'];
 
-export const toDatetimeLocal = (value: string): string => {
-  if (!value) return '';
-  return value.replace(' ', 'T').replace(/\./g, ':');
+export const splitDatetime = (value: string): { date: string; time: string } => {
+  if (!value) return { date: '', time: '' };
+  const normalized: string = value.replace(/\./g, ':');
+  const [date, time]: string[] = normalized.split(' ');
+  return { date: date ?? '', time: time ?? '' };
 };
 
-export const fromDatetimeLocal = (value: string): string => {
-  if (!value) return '';
-  return value.replace('T', ' ');
+export const combineDatetime = (date: string, time: string): string => {
+  if (!date || !time) return '';
+  return `${date} ${time}`;
 };
 
 export const formatDatetime = (date: Date): string => {

--- a/src/shared/util/datetime.ts
+++ b/src/shared/util/datetime.ts
@@ -3,6 +3,16 @@ import { DateTime, Duration } from 'luxon';
 
 export const formFormatDatetimes: string[] = ['yyyy-MM-dd HH:mm', 'yyyy-MM-dd HH.mm'];
 
+export const toDatetimeLocal = (value: string): string => {
+  if (!value) return '';
+  return value.replace(' ', 'T').replace(/\./g, ':');
+};
+
+export const fromDatetimeLocal = (value: string): string => {
+  if (!value) return '';
+  return value.replace('T', ' ');
+};
+
 export const formatDatetime = (date: Date): string => {
   const parsedTime: DateTime = DateTime.fromJSDate(date);
   if (!parsedTime.isValid) return '';


### PR DESCRIPTION
## Summary

Replace plain text datetime input with native date and time pickers for better UX, and fix inconsistent cancel confirmation behavior.

## Changes

### DateTime Picker
- Replace single text input with separate native `<input type="date">` and `<input type="time">` pickers
- Add `splitDatetime` and `combineDatetime` helpers in `datetime.ts`
- Keep "reset to now" button functionality
- Mobile users get OS-native pickers with better touch experience

### Bug Fix
- Fix cancel confirmation not showing for Juz activity when creating new activity
- Now all activity types (Juz, Surah, Ayah) consistently show confirmation on cancel

## Files Changed

| File | Change |
|------|--------|
| `src/module/activity/component/Form/Input/DateTimeInput.tsx` | Separate date/time inputs |
| `src/shared/util/datetime.ts` | Add split/combine helpers |
| `src/module/activity/component/Form/Button.tsx` | Fix cancel confirmation logic |

## Testing

- [x] Create activity by Juz - datetime picker works, cancel shows confirmation
- [x] Create activity by Surah - datetime picker works, cancel shows confirmation  
- [x] Create activity by Ayah - datetime picker works, cancel shows confirmation
- [x] Edit existing activity - datetime picker shows correct values
- [x] "Reset to now" button works
- [x] Mobile responsiveness (Android)