### PR TITLE
feat(activity): add range surah in surah form type

### DIFF
--- a/doc/pattern/pattern.md
+++ b/doc/pattern/pattern.md
@@ -342,8 +342,6 @@ If native datetime-local doesn't meet needs, consider:
 - **flatpickr** (~10KB) - Lightweight, dependency-free, more styling control
 - **react-datepicker** (~50KB) - Uses date-fns internally
 
-See `agent/story/MUR-11.md` for detailed comparison.
-
 ### Component Organization
 
 Follow the modular structure:

--- a/doc/pattern/pattern.md
+++ b/doc/pattern/pattern.md
@@ -302,6 +302,48 @@ export interface SharedProps {
 }
 ```
 
+### DateTime Input
+
+Use native `<input type="datetime-local">` for datetime selection. This provides:
+- Zero dependencies
+- Native browser/OS picker UI
+- Mobile-friendly experience
+- Built-in validation
+
+#### ✅ DO: Convert between Luxon and HTML datetime format
+
+```tsx
+// HTML datetime-local format: "yyyy-MM-ddTHH:mm"
+// Luxon format: "yyyy-MM-dd HH:mm"
+
+const toDatetimeLocal = (value: string): string => {
+  return value.replace(' ', 'T');
+};
+
+const fromDatetimeLocal = (value: string): string => {
+  return value.replace('T', ' ');
+};
+```
+
+#### ✅ DO: Keep "reset to now" button for UX
+
+```tsx
+<button
+  type="button"
+  onClick={() => setValue(DateTime.now().toFormat('yyyy-MM-dd HH:mm'))}
+>
+  <ArrowPathIcon />
+</button>
+```
+
+#### Alternatives Considered
+
+If native datetime-local doesn't meet needs, consider:
+- **flatpickr** (~10KB) - Lightweight, dependency-free, more styling control
+- **react-datepicker** (~50KB) - Uses date-fns internally
+
+See `agent/story/MUR-11.md` for detailed comparison.
+
 ### Component Organization
 
 Follow the modular structure:
@@ -472,7 +514,8 @@ useEffect(() => {
 | `useCallback`   | Passing to memoized children       | Simple handlers, no memoization  |
 | `useRef`        | Mutable value without re-render    | State that should trigger render |
 | Type annotation | Ambiguous types, complex unions    | Obvious inference, simple types  |
+| datetime-local  | Date + time input needed           | Need custom styling/theming      |
 
 ---
 
-_Last updated: 2026-02-15 02:49 AM
+_Last updated: 2026-02-17

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,10 @@
 :root {
 }
 
+html {
+  touch-action: pan-y;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,7 +36,7 @@ const RootLayout = ({ children }: Readonly<{ children: React.ReactNode }>): Reac
 
         <meta
           name="viewport"
-          content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, user-scalable=no, viewport-fit=cover"
+          content="minimum-scale=1, maximum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, user-scalable=no, viewport-fit=cover"
         />
 
         <link rel="apple-touch-icon" href="/icons/touch-icon-iphone.png" />

--- a/src/module/activity/component/Form/Content.tsx
+++ b/src/module/activity/component/Form/Content.tsx
@@ -90,11 +90,17 @@ const SurahContent = (p: Props): React.JSX.Element => {
 
   const handleModeChange = (mode: 'select' | 'range'): void => {
     if (mode !== surahMode) {
-      p.setSelectedSurah(undefined);
-      setStartSurah(undefined);
-      setEndSurah(undefined);
       setSearchInput('');
       setSurahMode(mode);
+
+      if (mode === 'range' && Array.isArray(p.selectedSurah) && p.selectedSurah.length > 0) {
+        setStartSurah(p.selectedSurah[0]);
+        setEndSurah(undefined);
+      } else {
+        p.setSelectedSurah(undefined);
+        setStartSurah(undefined);
+        setEndSurah(undefined);
+      }
     }
   };
 

--- a/src/module/activity/component/Form/Content.tsx
+++ b/src/module/activity/component/Form/Content.tsx
@@ -76,7 +76,15 @@ const SurahContent = (p: Props): React.JSX.Element => {
       const rangeOptions: Option[] = options.filter(
         (opt: Option) => opt.value >= startSurah.value && opt.value <= endSurah.value
       );
-      p.setSelectedSurah(rangeOptions.length > 0 ? rangeOptions : undefined);
+
+      const currentValues: number[] = Array.isArray(p.selectedSurah)
+        ? p.selectedSurah.map((o: Option) => o.value).sort()
+        : [];
+      const newValues: number[] = rangeOptions.map((o: Option) => o.value).sort();
+
+      if (JSON.stringify(currentValues) !== JSON.stringify(newValues)) {
+        p.setSelectedSurah(rangeOptions.length > 0 ? rangeOptions : undefined);
+      }
     }
   }, [surahMode, startSurah, endSurah, p]);
 

--- a/src/module/activity/component/Form/Content.tsx
+++ b/src/module/activity/component/Form/Content.tsx
@@ -252,7 +252,9 @@ const AyahContent = (p: Props): React.JSX.Element => {
   const selectedSurahId: number | undefined = Array.isArray(p.selectedSurah)
     ? p.selectedSurah[0]?.value
     : p.selectedSurah?.value;
-  const selectedSurahData: SurahType | undefined = surah.find((s: SurahType) => s.id === selectedSurahId);
+  const selectedSurahData: SurahType | undefined = surah.find(
+    (s: SurahType) => s.id === selectedSurahId
+  );
   const maxAyah: number = selectedSurahData?.totalAyah ?? 0;
 
   const isValidationEnabled: boolean = maxAyah > 0;


### PR DESCRIPTION
## Summary
Add "Range" mode to Surah activity form, allowing users to select contiguous surahs (e.g., Surah 1-5) via start/end dropdowns instead of clicking each surah individually in multi-select.

## Changes
- **Surah form**: Radio button to switch between "Select" (existing multi-select) and "Range" (start/end dropdowns) modes
- **ListSurahView integration**: Pre-selected surah becomes `startSurah` when switching to Range mode
- **Validation**: Error message shown when start > end
- **Mobile UX**: Disabled pinch zoom via `touch-action: pan-y`

## Files Changed
| File | Change |
|------|--------|
| `src/module/activity/component/Form/Content.tsx` | Surah range mode logic |
| `src/app/layout.tsx` | Viewport `maximum-scale=1` |
| `src/app/globals.css` | `touch-action: pan-y` |

## Test Plan
- [x] Select mode: single/multiple surahs creates N activities
- [x] Range mode: Surah 1-3 creates 3 activities
- [x] Invalid range (start > end) shows error
- [x] Edit mode uses Select mode (radio hidden)
- [x] ListSurahView: startSurah pre-filled in Range mode
- [x] No infinite loop on range selection
- [x] Pinch zoom disabled on Firefox Android